### PR TITLE
Fix item level calculation for Hunter range wapon

### DIFF
--- a/itemlevel.lua
+++ b/itemlevel.lua
@@ -392,6 +392,8 @@ function ArmoryUtils:UpdateChar(frame, unit, prefix, func)
 
                         if i == 16 and itemEquipLoc and itemEquipLoc == "INVTYPE_2HWEAPON" then
                             sum = sum + ilvl
+                        elseif i == 16 and itemEquipLoc and (itemEquipLoc == "INVTYPE_2HWEAPON" or (ArmoryUtils:GetWoWBuild() == "RETAIL" and (itemEquipLoc == "INVTYPE_RANGED" or itemEquipLoc == "INVTYPE_RANGEDRIGHT"))) then
+                            sum = sum + ilvl
                         end
 
                         if ArmoryUtils:DBGV("ITEMLEVEL" .. unit, true) then


### PR DESCRIPTION
Fix #3 
Hunter Ranged weapon should be also counted twice same as 2H weapon